### PR TITLE
Add wl-clipboard and cliphist packages with clipboard script

### DIFF
--- a/hosts/nixosbtw/modules/programs/packages.nix
+++ b/hosts/nixosbtw/modules/programs/packages.nix
@@ -1,6 +1,8 @@
 { pkgs, ... }:
 {
   environment.systemPackages = with pkgs; [
+    wl-clipboard
+    cliphist
     unzip
     cheese
     lsof

--- a/hosts/nixosbtw/users/viena/config/niri/config.kdl
+++ b/hosts/nixosbtw/users/viena/config/niri/config.kdl
@@ -1,6 +1,7 @@
 prefer-no-csd
 
 spawn-at-startup "swaync"
+spawn-at-startup "wl-paste --watch cliphist store"
 spawn-at-startup "awww-daemon"
 spawn-at-startup "awww img ../../../../../../asset/wallpapers/black_white_girl_with_sword.jpg"
 
@@ -140,7 +141,10 @@ cursor {
 }
 
 binds {
-    Mod+Shift+Slash { show-hotkey-overlay; }
+	Mod+Shift+Slash { show-hotkey-overlay; }
+
+	// Manage Clipboard
+	Mod+Alt+V {spawn-sh ".config/niri/scripts/clipManager.sh";}
 
     Mod+Return hotkey-overlay-title="Open a Terminal: kitty" { spawn "kitty"; }
     Alt+Shift+D {spawn "vesktop";}

--- a/hosts/nixosbtw/users/viena/config/niri/scripts/clipManager.sh
+++ b/hosts/nixosbtw/users/viena/config/niri/scripts/clipManager.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Clipboard Manager. This script uses cliphist, rofi, and wl-copy.
+
+# Variables
+msg='CTRL DEL = cliphist del (entry)   or   ALT DEL - cliphist wipe (all)'
+# Actions:
+# CTRL Del to delete an entry
+# ALT Del to wipe clipboard contents
+
+# Check if rofi is already running
+if pidof rofi > /dev/null; then
+  pkill rofi
+fi
+
+while true; do
+    result=$(
+        rofi -i -dmenu \
+            -kb-custom-1 "Control-Delete" \
+            -kb-custom-2 "Alt-Delete" \
+			-mesg "$msg" \
+            < <(cliphist list) 
+    )
+
+    case "$?" in
+        1)
+            exit
+            ;;
+        0)
+            case "$result" in
+                "")
+                    continue
+                    ;;
+                *)
+                    cliphist decode <<<"$result" | wl-copy
+                    exit
+                    ;;
+            esac
+            ;;
+        10)
+            cliphist delete <<<"$result"
+            ;;
+        11)
+            cliphist wipe
+            ;;
+    esac
+done
+


### PR DESCRIPTION
Closes #13 

- Saves copy to `cliphist` via `wl-clipboard`
- Later passes it to `rofi` to view the clipboard history and helps in copy and deleting history 